### PR TITLE
Apply target for TypeScript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10489,6 +10489,14 @@
         "shelljs": "^0.8.3",
         "typedoc-default-themes": "^0.6.0",
         "typescript": "3.5.x"
+      },
+      "dependencies": {
+        "typescript": {
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+          "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+          "dev": true
+        }
       }
     },
     "typedoc-default-themes": {
@@ -10504,9 +10512,9 @@
       }
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
+      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ts-node": "^8.3.0",
     "tslint": "^5.18.0",
     "typedoc": "^0.15.0",
-    "typescript": "^3.5.3"
+    "typescript": "^3.6.2"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Apply target `typescript-version::typescript-version`:

_TypeScript version_
```TypeScript version > ^3.6.2```

---
<details>
<summary>Commands</summary>
<br/>

You can trigger Atomist commands by commenting on this PR:
- `@atomist opt out` will stop raising automatic target PRs for this repository
- `@atomist help` start your comment with this to ask Atomist for help or provide feedback

[Link this repository to a Slack channel](https://app.atomist.com/workspace/T29E48P34/settings/integrations/slack?repo=atomist-blogs%2Fts-visualizer) to manage these updates directly from Slack.

</details>

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:typescript-version::typescript-version=2cac90486a49086e2fea735e51c6c8ed50674ef8f8293d4de62e91450b2facc1]</code>
</details>